### PR TITLE
styling: fix obscured text

### DIFF
--- a/client/src/components/layout/SpeedTest.tsx
+++ b/client/src/components/layout/SpeedTest.tsx
@@ -266,7 +266,7 @@ export default function SpeedTest() {
       {!showGameOverMenu && startTest && (
         <>
           {!startTimer && (
-            <div className="absolute left-1 top-20 z-30 flex rounded-xl bg-sky-700 px-5 py-2 font-nunito text-white lg:-left-6">
+            <div className="absolute -left-4 top-14 z-30 flex rounded-xl bg-sky-700 px-5 py-2 font-nunito text-white lg:-left-6">
               Start Typing!
             </div>
           )}

--- a/client/src/pages/Lesson.tsx
+++ b/client/src/pages/Lesson.tsx
@@ -87,7 +87,7 @@ function Lesson() {
           <>
             {" "}
             {!startTimer && (
-              <div className="absolute top-20 z-30 flex rounded-xl bg-sky-700 px-5 py-2 font-nunito text-white">
+              <div className="absolute -left-4 top-14 z-30 flex rounded-xl bg-sky-700 px-5 py-2 font-nunito text-white">
                 Start Typing!
               </div>
             )}


### PR DESCRIPTION
-Adjust position for 'start typing' banner so that it doesn't not obscure text.