### PR TITLE
styling: center headings

### DIFF
--- a/client/src/components/layout/lessonpg/LessonFourSecOne/LfourSeconeLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonFourSecOne/LfourSeconeLone.tsx
@@ -1,7 +1,7 @@
 export default function LfourSeconeLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Congratulations on Completing Your Typing Journey!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLeight.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfiveLeight() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering Typing: Learn To Type For adults and kids
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLfive.tsx
@@ -1,7 +1,7 @@
 function LoneSecfiveLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering Typing: Free typing classes for adults and children
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLfour.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfiveLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering Typing: Typing lessons for adults and kids
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLnine.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLnine.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfiveLnine() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering Typing: Unlocking the Power of the Keyboard
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLone.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfiveLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering Typing: Typing club for kids and adults
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLseven.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfiveLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering Typing: Typing test for kids and adults
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLsix.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfiveLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Unlocking the World of Typing: Typing practice for kids and adults
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLthree.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfiveLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering Typing: Typing lessons for adults and kids
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFive/LoneSecfiveLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfiveLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Unlocking the World of Typing: Typing for kids and adults
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLeight.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfourLeight() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center text-3xl font-bold leading-loose">
         Learn more about this words per minute typing test!
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLfive.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfourLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center text-3xl font-bold leading-loose">
         Learn more about this online typing test!
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLfour.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfourLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center text-3xl font-bold leading-loose">
         Lear more about this typing test online!
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLnine.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLnine.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecfourLnine() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center text-3xl font-bold leading-loose">
         Practice typing speed guide!
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLone.tsx
@@ -2,7 +2,7 @@ export default function LoneSecfourLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section className="mt-8">
-        <h2 className="mb-4 text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center text-3xl font-bold leading-loose">
           Welcome to Your Typing Lesson - Best typing program for kids and
           adults !
         </h2>

--- a/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLseven.tsx
@@ -2,7 +2,7 @@ export default function LoneSecfourLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section>
-        <h2 className="mb-4 text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center text-3xl font-bold leading-loose">
           Embark on Your Typing Journey - Free typing lessons for kids and
           adults!
         </h2>

--- a/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLsix.tsx
@@ -2,7 +2,7 @@ export default function LoneSecfourLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section>
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Welcome to Your First Typing Lesson - Typing programs for kids and
           adults!
         </h2>

--- a/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLthree.tsx
@@ -2,7 +2,7 @@ export default function LoneSecfourLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section>
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Adults and Kids typing practice!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecFour/LoneSecfourLtwo.tsx
@@ -2,7 +2,7 @@ export default function LoneSecfourLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section>
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Welcome to Your Speed Typing Journey!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLeight.tsx
@@ -2,7 +2,7 @@ export default function LoneSoneLeight() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section className="mb-8">
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Welcome to Typing Basics - Fun Typing Lessons Guide!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLfive.tsx
@@ -2,7 +2,7 @@ export default function LoneSoneLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section>
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           These lesson answer the following question: What is the fastest typing
           speed you want to achieve?{" "}
         </h2>

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLfour.tsx
@@ -2,7 +2,7 @@ export default function LoneSoneLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section>
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Welcome to Typing Basics - Free online Typing Speed Test Training!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLnine.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLnine.tsx
@@ -2,7 +2,7 @@ export default function LoneSoneLnine() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section className="mb-8">
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Now for the ASDF Typing Test!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLone.tsx
@@ -1,7 +1,7 @@
 function LoneSoneLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Learning to type letters of the alphabet "a" & "s"
       </h2>
       <div className="flex flex-col gap-4 pl-2">

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLseven.tsx
@@ -2,7 +2,7 @@ export default function LoneSoneLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section>
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Welcome to Typing Basics - Learn To Touch type read and spell!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">
@@ -119,7 +119,7 @@ export default function LoneSoneLseven() {
             <li>Press the "F" key and release.</li>
             <li>Return your finger to the home position.</li>
           </ol>
-          <p className="mb-4 pl-3 font-lato font-mono text-lg leading-loose text-slate-700">
+          <p className="mb-4 pl-3 font-lato  text-lg leading-loose text-slate-700">
             f f f f f f f f f f
           </p>
         </div>
@@ -132,7 +132,7 @@ export default function LoneSoneLseven() {
             <li>Press the "D" key and release.</li>
             <li>Return your finger to the home position.</li>
           </ol>
-          <p className="mb-4 pl-3 font-lato font-mono text-lg leading-loose text-slate-700">
+          <p className="mb-4 pl-3 font-lato  text-lg leading-loose text-slate-700">
             d d d d d d d d d d
           </p>
         </div>
@@ -145,7 +145,7 @@ export default function LoneSoneLseven() {
             <li>Press the "S" key and release.</li>
             <li>Return your finger to the home position.</li>
           </ol>
-          <p className="mb-4 pl-3 font-lato font-mono text-lg leading-loose text-slate-700">
+          <p className="mb-4 pl-3 font-lato  text-lg leading-loose text-slate-700">
             s s s s s s s s s s
           </p>
         </div>

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLsix.tsx
@@ -2,7 +2,7 @@ export default function LoneSoneLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section>
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Welcome to Typing Basics - Touch type strategic typing Lesson!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLten.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLten.tsx
@@ -1,7 +1,7 @@
 export default function LoneSoneLten() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Typing Basics - asdfasdf typing test!
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLthree.tsx
@@ -2,7 +2,7 @@ export default function LoneSoneLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section aria-labelledby="lesson-title">
-        <h2 id="lesson-title" className="mt-4 text-2xl font-bold">
+        <h2 id="lesson-title" className="mt-4 text-center text-2xl font-bold">
           Welcome to Typing Practice Test Lesson Basics!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecOne/LoneSoneLtwo.tsx
@@ -4,7 +4,7 @@ export default function LoneSoneLtwo() {
       <section aria-labelledby="lesson-title">
         <h2
           id="lesson-title"
-          className="mb-4 font-lora text-3xl font-bold leading-loose"
+          className="mb-4 text-center font-lora text-3xl font-bold leading-loose"
         >
           Welcome to Typing Basics and This Timed Typing Test Lesson!
         </h2>

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLeight.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLeight() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering the Keyboard: Typing Lessons Exercises Guide!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLfive.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering Typing: Touch Typing Practice!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLfour.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Learning to Type: What Is Touch Typing?
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLnine.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLnine.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLnine() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering the Top Row: A Beginner's Guide to Typing
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLone.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         About This Lesson: Learn Touch Typing!
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLseven.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering the Keyboard: The Best Typing Test Lesson On Google!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLsix.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         The Art of Typing: The One Minute Typing Test Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLten.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLten.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLten() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-2xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-2xl font-bold leading-loose">
         The Art and Science of Typing: A Breakdown Of This Free Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLthree.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering the Keyboard: Improve Your Typing Test Speed WPM!
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecSix/LoneSecsixLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LoneSecsixLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Mastering Typing: Improve Your Average Typing Speed!
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLeight.tsx
@@ -1,7 +1,7 @@
 export default function LoneSthreeLeight() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Your Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLfive.tsx
@@ -1,7 +1,7 @@
 export default function LoneSthreeLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Your First Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLfour.tsx
@@ -1,7 +1,7 @@
 export default function LoneSthreeLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Your First Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLnine.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLnine.tsx
@@ -2,7 +2,7 @@ export default function LoneSthreeLnine() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section className="mt-8">
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Welcome to Your Typing Lesson!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLone.tsx
@@ -2,7 +2,7 @@ export default function LoneSthreeLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section className="mt-8">
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Welcome to Your First Typing Lesson!
         </h2>
         <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLseven.tsx
@@ -2,7 +2,7 @@ export default function LoneSthreeLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
       <section className="mt-8">
-        <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+        <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
           Welcome to Your Typing Lesson - Typing Lessons For Desktop and Mobile
           (iPhone, Android, & more)!
         </h2>

--- a/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLsix.tsx
@@ -1,7 +1,7 @@
 export default function LoneSthreeLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Improve Your Typing Speed With These Lessons!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLthree.tsx
@@ -1,7 +1,7 @@
 export default function LoneSthreeLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         About These Typing Exercises For Beginners!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecThree/LoneSthreeLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LoneSthreeLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Your First Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLeight.tsx
@@ -1,7 +1,7 @@
 export default function LoneStwoLeight() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Your First Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLfive.tsx
@@ -1,7 +1,7 @@
 export default function LoneStwoLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Typing Lesson: Home Row Right Hand - ;k
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLfour.tsx
@@ -1,7 +1,7 @@
 export default function LoneStwoLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Your First Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLnine.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLnine.tsx
@@ -1,7 +1,7 @@
 export default function LoneStwoLnine() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Your First Typing Lesson!
       </h2>
       <p className="mb-6 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLone.tsx
@@ -1,7 +1,7 @@
 export default function LoneStwoLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to our typing lesson!
       </h2>
       <p className="mb-8 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLseven.tsx
@@ -1,7 +1,7 @@
 export default function LoneStwoLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Your First Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLsix.tsx
@@ -1,7 +1,7 @@
 export default function LoneStwoLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to Your First Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLthree.tsx
@@ -1,7 +1,7 @@
 export default function LoneStwoLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to your first typing lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonOneSecTwo/LoneStwoLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LoneStwoLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 text-center font-lora text-3xl font-bold leading-loose">
         Welcome to your first typing lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLeight.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSeconeLeight() {
   return (
     <article className="mx-auto max-w-3xl flex-col p-8 px-4 py-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Keyboard: A Comprehensive Guide to Typing
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLfive.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSeconeLfive() {
   return (
     <article className="mx-auto max-w-3xl flex-col p-8 px-4 py-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Learning How to Type: Mastering the Number Row - &*()_+
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLfour.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSeconeLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: Unlocking the Power of the Keyboard
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLone.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSeconeLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Basics: Learning to Type the Number Row
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLseven.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSeconeLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Unlocking the Potential of the Number Row: A Comprehensive Guide for
         Beginners
       </h2>

--- a/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLsix.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSeconeLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Number Row: A Beginner's Guide to Typing
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLthree.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSeconeLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: From Novice to Expert
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecOne/LthreeSeconeLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSeconeLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Basics: Learning to Type
       </h2>
       <section>

--- a/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLfive.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSecthreeLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Comprehensive Guide for Beginners
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLfour.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSecthreeLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Journey Through Symbols
       </h2>
       <section className="mb-8">

--- a/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLone.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSecthreeLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Comprehensive Guide
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLthree.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSecthreeLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Keyboard: A Comprehensive Guide to Typing
       </h2>
       <section className="mb-8">

--- a/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecThree/LthreeSecthreeLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSecthreeLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Keyboard: A Journey into Typing
       </h2>
       <section className="mb-8">

--- a/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLfive.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSectwoLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         The Art of Typing: A Comprehensive Guide for Beginners
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLfour.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSectwoLfour() {
   return (
     <article className="mx-auto flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         The Journey to Mastering Typing: A Comprehensive Guide for Beginners
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLone.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSectwoLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Introduction to Typing: A Beginner's Guide
       </h2>
       <section className="mb-6">

--- a/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLthree.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSectwoLthree() {
   return (
     <article className="mx-auto flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         The Art of Typing: Mastering the Keyboard with Brackets
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonThreeSecTwo/LthreeSectwoLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LthreeSectwoLtwo() {
   return (
     <article className="mx-auto max-w-3xl flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Introduction to Typing: Unlocking the World of Keyboards
       </h2>
       <section className="mb-6">

--- a/client/src/components/layout/lessonpg/LessonTwoSecFour/LtwoSecfourLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecFour/LtwoSecfourLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecfourLtwo() {
   return (
     <article className="mx-auto max-w-3xl px-4 py-8">
-      <h2 className="mb-4 text-3xl font-bold">
+      <h2 className="mb-4 text-3xl font-bold text-center">
         Mastering Typing: A Comprehensive Guide for Beginners
       </h2>
       <section className="mb-6">

--- a/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLeight.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSeconeLeight() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: Bottom Row Left Hand
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLfive.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSeconeLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Introduction to Typing: A Detailed Guide for Beginners
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLfour.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSeconeLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Introduction to Typing
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLnine.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLnine.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSeconeLnine() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: Your Gateway to Efficiency and Success
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLone.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSeconeLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Learning to Type: Bottom Row Left Hand - "zx"
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLseven.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSeconeLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Keyboard: A Comprehensive Guide to Typing
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLsix.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSeconeLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Keyboard: A Comprehensive Guide to Typing
       </h2>
 

--- a/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLthree.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSeconeLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: An Essential Skill for the Modern World
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecOne/LtwoSoneLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSeconeLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Learning to Type: A Comprehensive Guide for Beginners
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLeight.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLeight() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Bottom Row: A Beginner's Guide to Typing
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLfive.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         The Art of Typing: Mastering the Bottom Row
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLfour.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Journey from Novice to Proficient
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLnine.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLnine.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLnine() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Comprehensive Guide for Beginners
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLone.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Comprehensive Guide
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLseven.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Welcome to Your First Typing Lesson!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLsix.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Comprehensive Guide for Beginners
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLthree.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Beginner's Guide to the Bottom Row - zvn
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Welcome to the fascinating world of typing!
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeten.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecThree/LtwoSecthreeten.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSecthreeLten() {
   return (
     <article className="mx-auto max-w-3xl flex-col p-8 px-4 py-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Comprehensive Guide for Beginners
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLeight.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLeight.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSectwoLeight() {
   return (
     <article className="mx-auto max-w-3xl flex-col p-8 px-4 py-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: Unveiling the Secrets of the Bottom Row with Your
         Right Hand
       </h2>

--- a/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLfive.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLfive.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSectwoLfive() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Unlocking the Secrets of Typing: A Beginner's Guide
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLfour.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLfour.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSectwoLfour() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Embarking on Your Typing Odyssey: A Comprehensive Guide for Beginners
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLnine.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLnine.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSectwoLnine() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: A Beginner's Guide to the Bottom Row Right Hand -
         NM&lt;&gt;
       </h2>

--- a/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLone.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLone.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSectwoLone() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering the Art of Typing: The Journey Begins with the Bottom Row
         Right Hand
       </h2>

--- a/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLseven.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLseven.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSectwoLseven() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         The Art of Typing: Mastering the Bottom Row with Your Right Hand
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLsix.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLsix.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSectwoLsix() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Embarking on Your Typing Journey: Mastering the Bottom Row
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLthree.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLthree.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSectwoLthree() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Unlocking the World of Typing: A Comprehensive Guide
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">

--- a/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLtwo.tsx
+++ b/client/src/components/layout/lessonpg/LessonTwoSecTwo/LtwoSectwoLtwo.tsx
@@ -1,7 +1,7 @@
 export default function LtwoSectwoLtwo() {
   return (
     <article className="flex-col p-8 font-lora leading-loose tracking-wider text-sky-700">
-      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose">
+      <h2 className="mb-4 font-lora text-3xl font-bold leading-loose text-center">
         Mastering Typing: The Gateway to Efficiency and Success
       </h2>
       <p className="mb-4 pl-3 font-lato text-lg leading-loose text-slate-700">


### PR DESCRIPTION
-Center all article headings for lessons that aren't centered.