### PR TITLE
feat: performance starts

### DIFF
--- a/client/src/components/forms/homepg/DifficultySettings.tsx
+++ b/client/src/components/forms/homepg/DifficultySettings.tsx
@@ -54,19 +54,19 @@ function SettingName({ inputRef }: SettingNameProps) {
   const handleInputError = () => {
     if (!inputRef.current?.value) {
       return (
-        <span className="pt-2 text-sm text-red-400">
+        <span className="pt-2 text-center text-sm text-red-400">
           **Setting name cannot be empty**
         </span>
       );
     } else if (inputRef.current?.value.length > 24) {
       return (
-        <span className="pt-2 text-sm text-red-400">
+        <span className="pt-2 text-center text-sm text-red-400">
           **Setting name must be less than 25 characters**
         </span>
       );
     } else if (handleExistingName()) {
       return (
-        <span className="pt-2 text-sm text-red-400">
+        <span className="pt-2 text-center text-sm text-red-400">
           **Setting name already exists**
         </span>
       );
@@ -75,8 +75,8 @@ function SettingName({ inputRef }: SettingNameProps) {
 
   return (
     <div className="flex flex-col items-center justify-center gap-3">
-      <div className="flex items-center justify-center gap-3">
-        <label htmlFor="custom-difficulty" className="cursor-pointer">
+      <div className="flex flex-col items-center justify-center gap-3 text-sm sm:flex-row sm:text-base">
+        <label htmlFor="custom-difficulty" className="s cursor-pointer">
           Setting Name:
         </label>
         <input
@@ -92,7 +92,9 @@ function SettingName({ inputRef }: SettingNameProps) {
               handleExistingName()) &&
             "border-red-300"
           } rounded-md border-2 p-1 pl-4 text-base`}
-          onBlur={() => setBlurActive(true)}
+          onBlur={() => {
+            setTimeout(() => setBlurActive(true), 200);
+          }}
           onFocus={() => setBlurActive(false)}
         />
       </div>
@@ -195,7 +197,7 @@ function DifficultySettings({ setShowDifficultyMenu }: PropType) {
       return (
         <div
           id="difficulty-checkboxes"
-          className="relative mb-4 mt-2 grid grid-cols-3 gap-6"
+          className="relative mb-4 mt-2 grid gap-6 sm:grid-cols-3"
         >
           {customDifficultyOptions.map((option, index) => (
             <Fragment key={uuidv4()}>
@@ -402,7 +404,9 @@ function DifficultySettings({ setShowDifficultyMenu }: PropType) {
   );
 
   useEffect(() => {
-    const result = 1500 + calculateScore * 20;
+    const defaultBaseScore = 1500;
+    const scoreMultiplier = 20;
+    const result = defaultBaseScore + calculateScore * scoreMultiplier;
 
     setCurrentBonusScore(result);
 
@@ -438,6 +442,13 @@ function DifficultySettings({ setShowDifficultyMenu }: PropType) {
           <div className="flex w-full justify-evenly">
             <button
               type="button"
+              onClick={() => setCreateCustomSetting(false)}
+              className="rounded-md bg-red-500 px-6 py-2 tracking-wider text-white hover:scale-[1.03] hover:brightness-105"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
               onClick={() => {
                 if (
                   inputRef.current?.value &&
@@ -451,13 +462,6 @@ function DifficultySettings({ setShowDifficultyMenu }: PropType) {
               className="rounded-md bg-sky-500 px-6 py-2 tracking-wider text-white hover:scale-[1.03] hover:brightness-105"
             >
               Save
-            </button>
-            <button
-              type="button"
-              onClick={() => setCreateCustomSetting(false)}
-              className="rounded-md bg-sky-500 px-6 py-2 tracking-wider text-white hover:scale-[1.03] hover:brightness-105"
-            >
-              Cancel
             </button>
           </div>
         </>

--- a/client/src/components/hooks/usePerformanceStats.tsx
+++ b/client/src/components/hooks/usePerformanceStats.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import useAuth from "./useAuth";
+import useStats from "./useStats";
+import GetPerformanceStats from "../../utils/requests/GetPerformanceStats";
+
+interface PropType {
+  testNameList?: { testName: string }[];
+}
+
+//Fetch performance stats and store it in context
+function usePerformanceStats({ testNameList }: PropType) {
+  const { setPerformanceStats, performanceStats } = useStats();
+  const { userId } = useAuth();
+
+  useEffect(() => {
+    const fetchPerformanceData = async ({ testName }) => {
+      const performanceStats = await GetPerformanceStats({ testName, userId });
+
+      setPerformanceStats((prevState) => ({
+        ...prevState,
+        ...performanceStats,
+      }));
+    };
+
+    testNameList !== undefined &&
+      userId &&
+      testNameList.forEach((test) => {
+        if (!performanceStats[test.testName])
+          fetchPerformanceData({ testName: test.testName });
+      });
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setPerformanceStats, testNameList, userId]);
+}
+
+export default usePerformanceStats;

--- a/client/src/components/layout/shared/GameOverMenu.tsx
+++ b/client/src/components/layout/shared/GameOverMenu.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import loadable from "@loadable/component";
 import useAuth from "../../hooks/useAuth";
@@ -6,6 +6,7 @@ import useMenu from "../../hooks/useMenu";
 import usePreventDefaultInputs from "../../hooks/usePreventDefaultInputs";
 import useUpdateAllStats from "../../hooks/useUpdateAllStats";
 import FormatTime from "../../../utils/formatters/FormatTime";
+import useStats from "../../hooks/useStats";
 
 const PerformanceStars = loadable(
   () => import("../../ui/shared/PerformanceStars"),
@@ -119,8 +120,6 @@ export default function GameOverMenu({
   usePreventDefaultInputs(); // Disable space bar to stop unwanted behaviour after test ends
 
   const { hours, minutes, seconds } = FormatTime(testTime);
-  
- 
 
   useUpdateAllStats({
     setDisplayBestStats,
@@ -132,6 +131,26 @@ export default function GameOverMenu({
     score,
     testTime,
   });
+
+  const { performanceStats, setPerformanceStats } = useStats();
+
+  useEffect(() => {
+    //Update performance score on client side in context if performance score is higher than that stored in context
+    if (
+      performanceStats[testName] &&
+      performanceStats[testName].bestWPM < testStats.finalWPM
+    ) {
+      setPerformanceStats((prevState) => ({
+        ...prevState,
+        [testName]: {
+          bestWPM: testStats.finalWPM,
+          testTime: prevState[testName].testTime,
+        },
+      }));
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setPerformanceStats, testName, testStats]);
 
   useLayoutEffect(() => {
     Icon.load();

--- a/client/src/components/ui/homepg/SettingsModal.tsx
+++ b/client/src/components/ui/homepg/SettingsModal.tsx
@@ -18,15 +18,15 @@ function SettingsModal({ setShowDifficultyMenu }: PropType) {
   }, []);
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 top-0 z-50 m-auto flex h-full max-h-[100%] w-full items-center justify-center">
+    <div className="fixed bottom-0 left-0 right-0 top-0 z-50 m-auto flex h-full w-full items-center justify-center">
       <div
         id="modal-backdrop"
         data-testid="modal backdrop"
         aria-label="close settings menu button as background underlay"
-        className="absolute z-30 flex h-full w-full items-center justify-center bg-black opacity-40"
+        className="absolute z-30 flex h-full w-full items-center justify-center bg-black opacity-40 "
         onClick={() => setShowDifficultyMenu(false)}
       ></div>
-      <div className="relative z-30 flex min-h-[10em] w-full max-w-3xl flex-col items-center justify-center gap-6 rounded-xl bg-white px-10 py-10">
+      <div className="relative z-30 flex max-h-[100vh] min-h-[10em] w-full max-w-3xl flex-col items-center gap-6 overflow-auto rounded-xl bg-white px-10 py-10">
         <button
           className="absolute right-0 top-0 mx-3 my-2"
           onClick={() => setShowDifficultyMenu(false)}

--- a/client/src/components/ui/lessonspg/LessonsMenu.tsx
+++ b/client/src/components/ui/lessonspg/LessonsMenu.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { Fragment, useEffect, useLayoutEffect, useState } from "react";
 import useLessonText from "../../hooks/useLessonText";
 import loadable from "@loadable/component";
+import useStats from "../../hooks/useStats";
 
 const PerformanceStars = loadable(
   () => import("../../ui/shared/PerformanceStars"),
@@ -39,6 +40,8 @@ function SectionTitle({ sectionTitle }: PropType) {
 
 //Each link redirects to a specific lesson page
 function LevelLinks({ lesson, sectionIndex, lessonIndex }: LevelProps) {
+  const { performanceStats } = useStats(); //Gets performance score from context
+
   return (
     <ul className="mx-5 mb-4 grid w-full gap-x-4 gap-y-8 sm:grid-cols-2 sm:gap-12 md:grid-cols-3 lg:grid-cols-4 lg:gap-x-8">
       {lesson?.sectionData?.map((section, levelIndex) => (
@@ -51,7 +54,16 @@ function LevelLinks({ lesson, sectionIndex, lessonIndex }: LevelProps) {
           >
             <PerformanceStars
               customStyle={"absolute -bottom-[1.25rem] flex "}
-              performanceScore={0}
+              wpm={
+                performanceStats[
+                  `lesson/${lessonIndex + 1}/sec-${sectionIndex + 1}/lvl-${
+                    levelIndex + 1
+                  }`
+                ]?.bestWPM
+              }
+              testName={`lesson/${lessonIndex + 1}/sec-${
+                sectionIndex + 1
+              }/lvl-${levelIndex + 1}`}
             />
             <span>Level: {levelIndex + 1}</span>
             <span className="text-xs capitalize">{section.levelTitle}</span>

--- a/client/src/components/ui/shared/PerformanceStars.tsx
+++ b/client/src/components/ui/shared/PerformanceStars.tsx
@@ -2,7 +2,6 @@ import { Fragment, useEffect, useState } from "react";
 import Icon from "../../../utils/other/Icon";
 import { v4 as uuidv4 } from "uuid";
 import CalcPerformanceScore from "../../../utils/calculations/CalcPerformanceScore";
-import useLessonText from "../../hooks/useLessonText";
 
 interface PropType {
   customStyle: string;
@@ -18,7 +17,6 @@ export default function PerformanceStars({
   testTime,
   wpm,
 }: PropType) {
-  const { lessonIndex } = useLessonText();
   const [performanceScore, setPerformanceScore] = useState<number>(0);
 
   const starArr = new Array(5).fill("");
@@ -48,14 +46,17 @@ export default function PerformanceStars({
   useEffect(() => {
     const handlePerformanceScore = () => {
       let starOffset = 0;
+      const timeOffset = Math.ceil(testTime / 20) + 5;
 
-      if (testName === "calculator-game" && wpm > 10)
-        starOffset = Math.ceil(testTime / 60); //For this test the player is rewarded for both wpm and how long they last in the game. For each minute the player survives they get 1 extra star.
+      if (testName === "calculator-game" && wpm >= 10)
+        starOffset = timeOffset > 7 ? 7 : timeOffset; //For this test the player is rewarded for both wpm and how long they last in the game. For each minute the player survives they get 1 extra star.
 
-      console.log(testName, testTime);
-
-      //For the first 3 lessons be more lenient and award 3 extra points.
-      if (typeof lessonIndex === "number" && lessonIndex <= 2 && wpm > 10)
+      if (
+        (testName?.includes("lesson/1/") ||
+          testName?.includes("lesson/2/") ||
+          testName?.includes("lesson/3/")) &&
+        wpm > 10
+      )
         starOffset = 3;
 
       const score = CalcPerformanceScore({
@@ -66,7 +67,7 @@ export default function PerformanceStars({
     };
 
     setPerformanceScore(handlePerformanceScore());
-  }, [lessonIndex, testName, testTime, wpm]);
+  }, [testName, testTime, wpm]);
 
   return (
     <div className={customStyle}>
@@ -76,7 +77,7 @@ export default function PerformanceStars({
             icon={`${handleStarIcon(index)}`}
             title="Performance Stars Based On WPM"
             customStyle={`${styleArr[index]} ${
-              handleStarIcon(index) === "starEmpty"
+              handleStarIcon(index) !== "starFull"
                 ? "text-slate-400"
                 : "text-sky-500"
             } bg-white rounded-full`}

--- a/client/src/pages/Games.tsx
+++ b/client/src/pages/Games.tsx
@@ -3,6 +3,8 @@ import calculator from "../assets/images/calculator.png";
 import loadable from "@loadable/component";
 import { useLayoutEffect } from "react";
 import useLoadAnimation from "../components/hooks/useLoadAnimation";
+import useStats from "../components/hooks/useStats";
+import usePerformanceStats from "../components/hooks/usePerformanceStats";
 
 const PerformanceStars = loadable(
   () => import("../components/ui/shared/PerformanceStars"),
@@ -10,15 +12,21 @@ const PerformanceStars = loadable(
 const SpeedCalculatorGame = loadable(() => import("./CalculatorGame"));
 
 function Games() {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const gamesList = [
     {
       id: "game_1",
       thumbnail: "thumbnail",
       title: "Calculator",
+      testName: "calculator-game",
       url: "/games/calculator",
       componentName: SpeedCalculatorGame,
     },
   ];
+
+  const { performanceStats } = useStats(); //Gets performance score from context
+
+  usePerformanceStats({ testNameList: gamesList }); //Handles fetching of performance scores and saves to context
 
   const { fadeAnim } = useLoadAnimation();
 
@@ -52,7 +60,9 @@ function Games() {
           >
             <PerformanceStars
               customStyle={"absolute -bottom-[1.25rem] flex "}
-              performanceScore={0}
+              testName={item.testName}
+              testTime={performanceStats[item.testName]?.testTime}
+              wpm={performanceStats[item.testName]?.bestWPM}
             />
             <img
               alt="Typing game link preview"

--- a/client/src/pages/Lessons.tsx
+++ b/client/src/pages/Lessons.tsx
@@ -1,16 +1,64 @@
-import { useLayoutEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
 import loadable from "@loadable/component";
 import LessonMenuData from "../data/LessonMenuData";
+import useLessonText from "../components/hooks/useLessonText";
+import usePerformanceStats from "../components/hooks/usePerformanceStats";
 
 const SidebarMenu = loadable(
   () => import("../components/ui/navigation/SidebarMenu"),
 );
 
+type lessonURLType = { [key: string]: [{ testName: string }] };
+
 export default function Lessons() {
   const [displayLesson, setDisplayLesson] = useState<number>(0); //Used to manage which menu section is to be displayed
   const navigate = useNavigate();
   const sidebarMenuData = useMemo(() => LessonMenuData(), []);
+  const [lessonURLs, setLessonURLs] = useState<lessonURLType>({}); //List of all urls for each lesson section
+
+  const { allLessonData } = useLessonText();
+  const lessonName = location.pathname.split("/")[2];
+
+  //Generates a list of all lesson urls which are the same as the test names saved in db for each lesson. It will be used to fetch performance scores for all lessons.
+  useEffect(() => {
+    const handelGenURLs = () => {
+      const allURLs = {};
+      allLessonData.forEach((lesson, lessonIndex) =>
+        lesson.lessonData.forEach((section, sectionIndex) =>
+          section.sectionData.forEach((_level, levelIndex) => {
+            if (allURLs[lesson.id]) {
+              allURLs[lesson.id].push({
+                testName: `lesson/${lessonIndex + 1}/sec-${
+                  sectionIndex + 1
+                }/lvl-${levelIndex + 1}`,
+              });
+            } else {
+              allURLs[lesson.id] = [
+                {
+                  testName: `lesson/${lessonIndex + 1}/sec-${
+                    sectionIndex + 1
+                  }/lvl-${levelIndex + 1}`,
+                },
+              ];
+            }
+          }),
+        ),
+      );
+
+      setLessonURLs(allURLs);
+    };
+
+    if (
+      Object.keys(lessonURLs).length === 0 &&
+      !location.pathname.includes("lessons/lesson/")
+    )
+      handelGenURLs();
+  }, [allLessonData, lessonName, lessonURLs]);
+
+  usePerformanceStats({
+    testNameList: lessonURLs[lessonName],
+  }); //Handles fetching of performance scores and saves to context
 
   useLayoutEffect(() => {
     if (location.pathname === "/lessons") navigate("/lessons/beginner");

--- a/client/src/providers/StatsProvider.tsx
+++ b/client/src/providers/StatsProvider.tsx
@@ -7,6 +7,14 @@ interface ContextType {
   setWeeklyStats: (value: { [key: string]: string | number }) => void;
   lifetimeStats: { [key: string]: string | number };
   setLifetimeStats: (value: { [key: string]: string | number }) => void;
+  performanceStats: { [key: string]: { testTime: number; bestWPM: number } };
+  setPerformanceStats: (
+    value: (prevState: {
+      [key: string]: { testTime: number; bestWPM: number };
+    }) => {
+      [key: string]: { testTime: number; bestWPM: number };
+    },
+  ) => void;
   level: number;
   setLevel: (value: number) => void;
 }
@@ -18,6 +26,8 @@ export const StatsContext = createContext<ContextType>({
   setWeeklyStats: () => {},
   lifetimeStats: {},
   setLifetimeStats: () => {},
+  performanceStats: {},
+  setPerformanceStats: () => {},
   level: 0,
   setLevel: () => 0,
 });
@@ -35,6 +45,9 @@ export default function StatsProvider({ children }: PropType) {
   const [lifetimeStats, setLifetimeStats] = useState<{
     [key: string]: string | number;
   }>({});
+  const [performanceStats, setPerformanceStats] = useState<{
+    [key: string]: { testTime: number; bestWPM: number };
+  }>({}); //The test name is the identifier (key) for the object values (value). eg. calculator-game will have a testTime and bestWPM associated with the keyword.
 
   return (
     <StatsContext.Provider
@@ -46,7 +59,9 @@ export default function StatsProvider({ children }: PropType) {
         lifetimeStats,
         setLifetimeStats,
         level,
-        setLevel
+        setLevel,
+        performanceStats,
+        setPerformanceStats,
       }}
     >
       {children}

--- a/client/src/utils/requests/GetPerformanceStats.ts
+++ b/client/src/utils/requests/GetPerformanceStats.ts
@@ -1,18 +1,20 @@
 import AccountAPI from "../../api/accountAPI";
 interface PropType {
   userId: string;
+  testName: string;
 }
-
-export default async function GetLifetimeStats({ userId }: PropType) {
+export default async function GetPerformanceStats({
+  userId,
+  testName,
+}: PropType) {
   let statsData = {};
 
-  //Quick test to see if request is called too many times
-  // console.log("get header stats runs");
   try {
-    const response = await AccountAPI.get("/lifetime-stats", {
+    const response = await AccountAPI.get("/performance-stats", {
       method: "GET",
       params: {
         userId,
+        testName,
       },
     })
       .then((response) => {
@@ -26,9 +28,9 @@ export default async function GetLifetimeStats({ userId }: PropType) {
 
     if (parseRes) {
       statsData = parseRes;
-      return parseRes;
+      return statsData;
     } else {
-      console.log("Error fetching header stats");
+      console.log("Error fetching performance stats");
     }
   } catch (err) {
     let message: string;

--- a/server/routes/accountRouter.tsx
+++ b/server/routes/accountRouter.tsx
@@ -338,4 +338,39 @@ router.get("/best-stats", async (req: Request, res: Response) => {
   }
 });
 
+router.get("/performance-stats", async (req: Request, res: Response) => {
+  try {
+    const { userId, testName } = req.query;
+
+    // Validation
+    validateString(userId, "User id");
+    validateString(testName, "Test name");
+
+    // Retrieve user info based on valid user id
+    const getBestPerformance = await pool.query(
+      `
+      SELECT wpm, test_time_sec 
+      FROM score 
+      WHERE user_id = $1 AND test_name = $2 
+      ORDER BY wpm DESC 
+      LIMIT 1
+  `,
+      [userId, testName]
+    );
+
+    res.json({
+      [`${testName}`]: {
+        bestWPM: getBestPerformance?.rows[0]?.wpm || 0,
+        testTime: getBestPerformance?.rows[0]?.test_time_sec || 0,
+      },
+    });
+  } catch (err: any) {
+    console.error("An error occurred while fetching score:", err);
+    if (err instanceof Error) {
+      console.error("Error message:", err.message);
+    }
+    res.status(500).json({ error: "Server Error" });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
-Add logic to fetch and display performance stars on games and lessons menus after storing performance score in context. -When a test is completed, update performance score for that test in context.