### PR TITLE
fix: performance stars stutter bug

### DIFF
--- a/client/src/components/hooks/usePerformanceStats.tsx
+++ b/client/src/components/hooks/usePerformanceStats.tsx
@@ -16,17 +16,24 @@ function usePerformanceStats({ testNameList }: PropType) {
     const fetchPerformanceData = async ({ testName }) => {
       const performanceStats = await GetPerformanceStats({ testName, userId });
 
-      setPerformanceStats((prevState) => ({
-        ...prevState,
-        ...performanceStats,
-      }));
+      if (performanceStats[testName].bestWPM !== 0)
+        setPerformanceStats((prevState) => ({
+          ...prevState,
+          ...performanceStats,
+        }));
     };
 
     testNameList !== undefined &&
       userId &&
+      !performanceStats[testNameList[testNameList?.length - 1]?.testName] &&
       testNameList.forEach((test) => {
-        if (!performanceStats[test.testName])
-          fetchPerformanceData({ testName: test.testName });
+        //Save all default performance stat as 0 so that stars display as 0 by default which provides a better user exp
+        setPerformanceStats((prevState) => ({
+          ...prevState,
+          [test.testName]: { bestWPM: 0, testTime: 0 },
+        }));
+
+        fetchPerformanceData({ testName: test.testName });
       });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/components/ui/shared/PerformanceStars.tsx
+++ b/client/src/components/ui/shared/PerformanceStars.tsx
@@ -46,10 +46,9 @@ export default function PerformanceStars({
   useEffect(() => {
     const handlePerformanceScore = () => {
       let starOffset = 0;
-      const timeOffset = Math.ceil(testTime / 20) + 5;
+      const timeOffset = Math.ceil(testTime / 15);
 
-      if (testName === "calculator-game" && wpm >= 10)
-        starOffset = timeOffset > 7 ? 7 : timeOffset; //For this test the player is rewarded for both wpm and how long they last in the game. For each minute the player survives they get 1 extra star.
+      if (testName === "calculator-game" && wpm >= 10) starOffset = timeOffset;
 
       if (
         (testName?.includes("lesson/1/") ||


### PR DESCRIPTION
-Before fetching performance star stats from db, save default performance stats as 0 in context so the starts being displayed don't stutter each time empty stats are updated after being fetched.